### PR TITLE
Bugfixes for Django 1.6 backwards compatibility.

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1041,6 +1041,10 @@ def create_usersettings(sender, instance, created, **kwargs):
         UserSettings.objects.create(user=instance, settings=DEFAULT_USER_SETTINGS)
 
 try:
+    # Connecting via settings.AUTH_USER_MODEL (string) fails in Django < 1.7. We need the actual model there.
+    # https://docs.djangoproject.com/en/1.7/topics/auth/customizing/#referencing-the-user-model
+    if django.VERSION < (1, 7):
+        raise ValueError
     models.signals.post_save.connect(create_usersettings, sender=settings.AUTH_USER_MODEL)
 except:
     signal_user = get_user_model()

--- a/helpdesk/south_migrations/0010_auto__add_field_queue_socks_proxy_type__add_field_queue_socks_proxy_ho.py
+++ b/helpdesk/south_migrations/0010_auto__add_field_queue_socks_proxy_type__add_field_queue_socks_proxy_ho.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import SchemaMigration
+from django.db import models
+
+
+class Migration(SchemaMigration):
+
+    def forwards(self, orm):
+        # Adding field 'Queue.socks_proxy_type'
+        db.add_column(u'helpdesk_queue', 'socks_proxy_type',
+                      self.gf('django.db.models.fields.CharField')(max_length=8, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Queue.socks_proxy_host'
+        db.add_column(u'helpdesk_queue', 'socks_proxy_host',
+                      self.gf('django.db.models.fields.GenericIPAddressField')(max_length=39, null=True, blank=True),
+                      keep_default=False)
+
+        # Adding field 'Queue.socks_proxy_port'
+        db.add_column(u'helpdesk_queue', 'socks_proxy_port',
+                      self.gf('django.db.models.fields.IntegerField')(null=True, blank=True),
+                      keep_default=False)
+
+
+    def backwards(self, orm):
+        # Deleting field 'Queue.socks_proxy_type'
+        db.delete_column(u'helpdesk_queue', 'socks_proxy_type')
+
+        # Deleting field 'Queue.socks_proxy_host'
+        db.delete_column(u'helpdesk_queue', 'socks_proxy_host')
+
+        # Deleting field 'Queue.socks_proxy_port'
+        db.delete_column(u'helpdesk_queue', 'socks_proxy_port')
+
+
+    models = {
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'auth.user': {
+            'Meta': {'object_name': 'User'},
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'helpdesk.attachment': {
+            'Meta': {'ordering': "['filename']", 'object_name': 'Attachment'},
+            'file': ('django.db.models.fields.files.FileField', [], {'max_length': '1000'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '1000'}),
+            'followup': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['helpdesk.FollowUp']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mime_type': ('django.db.models.fields.CharField', [], {'max_length': '255'}),
+            'size': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'helpdesk.customfield': {
+            'Meta': {'object_name': 'CustomField'},
+            'data_type': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'decimal_places': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'empty_selection_list': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'help_text': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'label': ('django.db.models.fields.CharField', [], {'max_length': "'30'"}),
+            'list_values': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'max_length': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.SlugField', [], {'unique': 'True', 'max_length': '50'}),
+            'ordering': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'required': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'staff_only': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'helpdesk.emailtemplate': {
+            'Meta': {'ordering': "['template_name', 'locale']", 'object_name': 'EmailTemplate'},
+            'heading': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'html': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'plain_text': ('django.db.models.fields.TextField', [], {}),
+            'subject': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'template_name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'helpdesk.escalationexclusion': {
+            'Meta': {'object_name': 'EscalationExclusion'},
+            'date': ('django.db.models.fields.DateField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'queues': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['helpdesk.Queue']", 'null': 'True', 'blank': 'True'})
+        },
+        u'helpdesk.followup': {
+            'Meta': {'ordering': "['date']", 'object_name': 'FollowUp'},
+            'comment': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'date': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'new_status': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'public': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'ticket': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['helpdesk.Ticket']"}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        u'helpdesk.ignoreemail': {
+            'Meta': {'object_name': 'IgnoreEmail'},
+            'date': ('django.db.models.fields.DateField', [], {'blank': 'True'}),
+            'email_address': ('django.db.models.fields.CharField', [], {'max_length': '150'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'keep_in_mailbox': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'queues': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['helpdesk.Queue']", 'null': 'True', 'blank': 'True'})
+        },
+        u'helpdesk.kbcategory': {
+            'Meta': {'ordering': "['title']", 'object_name': 'KBCategory'},
+            'description': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'helpdesk.kbitem': {
+            'Meta': {'ordering': "['title']", 'object_name': 'KBItem'},
+            'answer': ('django.db.models.fields.TextField', [], {}),
+            'category': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['helpdesk.KBCategory']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_updated': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'question': ('django.db.models.fields.TextField', [], {}),
+            'recommendations': ('django.db.models.fields.IntegerField', [], {'default': '0'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'votes': ('django.db.models.fields.IntegerField', [], {'default': '0'})
+        },
+        u'helpdesk.presetreply': {
+            'Meta': {'ordering': "['name']", 'object_name': 'PreSetReply'},
+            'body': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'queues': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'to': u"orm['helpdesk.Queue']", 'null': 'True', 'blank': 'True'})
+        },
+        u'helpdesk.queue': {
+            'Meta': {'ordering': "('title',)", 'object_name': 'Queue'},
+            'allow_email_submission': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'allow_public_submission': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'email_address': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'email_box_host': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'email_box_imap_folder': ('django.db.models.fields.CharField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'email_box_interval': ('django.db.models.fields.IntegerField', [], {'default': "'5'", 'null': 'True', 'blank': 'True'}),
+            'email_box_last_check': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'email_box_pass': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'email_box_port': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'email_box_ssl': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'email_box_type': ('django.db.models.fields.CharField', [], {'max_length': '5', 'null': 'True', 'blank': 'True'}),
+            'email_box_user': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'escalate_days': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'locale': ('django.db.models.fields.CharField', [], {'max_length': '10', 'null': 'True', 'blank': 'True'}),
+            'new_ticket_cc': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50'}),
+            'socks_proxy_host': ('django.db.models.fields.GenericIPAddressField', [], {'max_length': '39', 'null': 'True', 'blank': 'True'}),
+            'socks_proxy_port': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'socks_proxy_type': ('django.db.models.fields.CharField', [], {'max_length': '8', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'updated_ticket_cc': ('django.db.models.fields.CharField', [], {'max_length': '200', 'null': 'True', 'blank': 'True'})
+        },
+        u'helpdesk.savedsearch': {
+            'Meta': {'object_name': 'SavedSearch'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'query': ('django.db.models.fields.TextField', [], {}),
+            'shared': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']"})
+        },
+        u'helpdesk.ticket': {
+            'Meta': {'ordering': "('id',)", 'object_name': 'Ticket'},
+            'assigned_to': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'assigned_to'", 'null': 'True', 'to': u"orm['auth.User']"}),
+            'created': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'description': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'due_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'last_escalation': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'modified': ('django.db.models.fields.DateTimeField', [], {'blank': 'True'}),
+            'on_hold': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'priority': ('django.db.models.fields.IntegerField', [], {'default': '3', 'blank': '3'}),
+            'queue': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['helpdesk.Queue']"}),
+            'resolution': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'status': ('django.db.models.fields.IntegerField', [], {'default': '1'}),
+            'submitter_email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            'title': ('django.db.models.fields.CharField', [], {'max_length': '200'})
+        },
+        u'helpdesk.ticketcc': {
+            'Meta': {'object_name': 'TicketCC'},
+            'can_update': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'can_view': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ticket': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['helpdesk.Ticket']"}),
+            'user': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.User']", 'null': 'True', 'blank': 'True'})
+        },
+        u'helpdesk.ticketchange': {
+            'Meta': {'object_name': 'TicketChange'},
+            'field': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'followup': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['helpdesk.FollowUp']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'new_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'old_value': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'helpdesk.ticketcustomfieldvalue': {
+            'Meta': {'object_name': 'TicketCustomFieldValue'},
+            'field': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['helpdesk.CustomField']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ticket': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['helpdesk.Ticket']"}),
+            'value': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'helpdesk.ticketdependency': {
+            'Meta': {'unique_together': "(('ticket', 'depends_on'),)", 'object_name': 'TicketDependency'},
+            'depends_on': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'depends_on'", 'to': u"orm['helpdesk.Ticket']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'ticket': ('django.db.models.fields.related.ForeignKey', [], {'related_name': "'ticketdependency'", 'to': u"orm['helpdesk.Ticket']"})
+        },
+        u'helpdesk.usersettings': {
+            'Meta': {'object_name': 'UserSettings'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'settings_pickled': ('django.db.models.fields.TextField', [], {'null': 'True', 'blank': 'True'}),
+            'user': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.User']", 'unique': 'True'})
+        }
+    }
+
+    complete_apps = ['helpdesk']

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from distutils.util import convert_path
 from fnmatch import fnmatchcase
 from setuptools import setup, find_packages
 
-version = '0.1.14'
+version = '0.1.15'
 
 # Provided as an attribute, so you can append to these instead
 # of replicating them:


### PR DESCRIPTION
Added south migration to populate the initially existing users with usersettings - Closes rossp/django-helpdesk#297. 
In Django < 1.7, if settings.AUTH_USER_MODEL is defined, the sender is expected to be the actual instance, not a string - Closes rossp/django-helpdesk#295 by checking for django version < 1.7.