### PR TITLE
Remove deprecated load url from future

### DIFF
--- a/helpdesk/templates/helpdesk/base.html
+++ b/helpdesk/templates/helpdesk/base.html
@@ -1,5 +1,4 @@
 {% load i18n %}
-{% load url from future %}
 {% load saved_queries %}
 {% load load_helpdesk_settings %}
 {% with request|load_helpdesk_settings as helpdesk_settings %}

--- a/helpdesk/templates/helpdesk/email_ignore_list.html
+++ b/helpdesk/templates/helpdesk/email_ignore_list.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n %}
 
 {% block helpdesk_title %}{% trans "Ignored E-Mail Addresses" %}{% endblock %}
 

--- a/helpdesk/templates/helpdesk/help_api.html
+++ b/helpdesk/templates/helpdesk/help_api.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/help_base.html" %}{% load url from future %}
+{% extends "helpdesk/help_base.html" %}
 
 {% block title %}django-helpdesk API Documentation{% endblock %}
 {% block heading %}django-helpdesk API Documentation{% endblock %}

--- a/helpdesk/templates/helpdesk/help_base.html
+++ b/helpdesk/templates/helpdesk/help_base.html
@@ -1,4 +1,3 @@
-{% load url from future %}
 <html>
     <head>
         <style type='text/css'>

--- a/helpdesk/templates/helpdesk/include/stats.html
+++ b/helpdesk/templates/helpdesk/include/stats.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load url from future %}
+{% load i18n %}
 <table class="table table-hover table-bordered table-striped ticket-stats">
 <caption>{% trans "Current Ticket Stats" %}</caption>
 <thead>

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -1,4 +1,4 @@
-{% load i18n humanize %}{% load url from future %}
+{% load i18n humanize %}
 <table class="table table-hover table-bordered table-striped">{% if ticket_list_caption %}
 <caption>{{ ticket_list_caption }}</caption>{% endif %}
 <thead>

--- a/helpdesk/templates/helpdesk/include/unassigned.html
+++ b/helpdesk/templates/helpdesk/include/unassigned.html
@@ -1,4 +1,4 @@
-{% load i18n humanize %}{% load url from future %}
+{% load i18n humanize %}
 <table class="table table-hover table-bordered table-striped">
 <caption>{% trans "Unassigned Tickets" %} {% trans "(pick up a ticket if you start to work on it)" %}</caption>
 <thead>

--- a/helpdesk/templates/helpdesk/navigation.html
+++ b/helpdesk/templates/helpdesk/navigation.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load url from future %}
+{% load i18n %}
 
 <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
     <div class="navbar-header">

--- a/helpdesk/templates/helpdesk/public_base.html
+++ b/helpdesk/templates/helpdesk/public_base.html
@@ -1,4 +1,4 @@
-{% load i18n %}{% load url from future %}
+{% load i18n %}
 {% load load_helpdesk_settings %}
 {% with request|load_helpdesk_settings as helpdesk_settings %}
 <html>

--- a/helpdesk/templates/helpdesk/public_homepage.html
+++ b/helpdesk/templates/helpdesk/public_homepage.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/public_base.html" %}{% load i18n bootstrap %}{% load url from future %}
+{% extends "helpdesk/public_base.html" %}{% load i18n bootstrap %}
 
 {% block helpdesk_body %}
 

--- a/helpdesk/templates/helpdesk/public_view_form.html
+++ b/helpdesk/templates/helpdesk/public_view_form.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/public_base.html" %}{% load i18n %}{% load url from future %}
+{% extends "helpdesk/public_base.html" %}{% load i18n %}
 
 {% block helpdesk_body %}
 <h2>{% trans "View a Ticket" %}</h2>

--- a/helpdesk/templates/helpdesk/rss_list.html
+++ b/helpdesk/templates/helpdesk/rss_list.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n %}
 {% block helpdesk_title %}{% trans "RSS Feeds" %}{% endblock %}
 {% block helpdesk_body %}
 <h2>{% trans "RSS Feeds" %}</h2>

--- a/helpdesk/templates/helpdesk/system_settings.html
+++ b/helpdesk/templates/helpdesk/system_settings.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n %}{% load url from future %}{% load user_admin_url %}
+{% extends "helpdesk/base.html" %}{% load i18n %}{% load user_admin_url %}
 
 {% block helpdesk_title %}{% trans "Change System Settings" %}{% endblock %}
 

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n bootstrap humanize %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n bootstrap humanize %}
 {% block helpdesk_title %}{% trans "View Ticket Details" %}{% endblock %}
 {% block helpdesk_head %}
 <script type="text/javascript">

--- a/helpdesk/templates/helpdesk/ticket_cc_add.html
+++ b/helpdesk/templates/helpdesk/ticket_cc_add.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n %}
 
 {% block helpdesk_title %}{% trans "Add Ticket CC" %}{% endblock %}
 

--- a/helpdesk/templates/helpdesk/ticket_cc_del.html
+++ b/helpdesk/templates/helpdesk/ticket_cc_del.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n %}
 
 {% block helpdesk_title %}{% trans "Delete Ticket CC" %}{% endblock %}
 

--- a/helpdesk/templates/helpdesk/ticket_cc_list.html
+++ b/helpdesk/templates/helpdesk/ticket_cc_list.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n %}
 
 {% block helpdesk_title %}{% trans "Ticket CC Settings" %}{% endblock %}
 

--- a/helpdesk/templates/helpdesk/ticket_dependency_add.html
+++ b/helpdesk/templates/helpdesk/ticket_dependency_add.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n %}
 
 {% block helpdesk_title %}{% trans "Add Ticket Dependency" %}{% endblock %}
 

--- a/helpdesk/templates/helpdesk/ticket_dependency_del.html
+++ b/helpdesk/templates/helpdesk/ticket_dependency_del.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n %}
 
 {% block helpdesk_title %}{% trans "Delete Ticket Dependency" %}{% endblock %}
 

--- a/helpdesk/templates/helpdesk/ticket_desc_table.html
+++ b/helpdesk/templates/helpdesk/ticket_desc_table.html
@@ -1,4 +1,4 @@
-{% load i18n humanize %}{% load url from future %}
+{% load i18n humanize %}
 <table class="table table-hover table-bordered table-striped">
 <thead>
     <tr class='row_tablehead'><td colspan='2'><h3>{{ ticket.id }}. {{ ticket.title }} [{{ ticket.get_status }}]</h3> <span class='ticket_toolbar'>

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n humanize %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n humanize %}
 {% block helpdesk_title %}{% trans "Tickets" %}{% endblock %}
 {% block helpdesk_head %}
 

--- a/helpdesk/templates/helpdesk/user_settings.html
+++ b/helpdesk/templates/helpdesk/user_settings.html
@@ -1,4 +1,4 @@
-{% extends "helpdesk/base.html" %}{% load i18n bootstrap %}{% load url from future %}
+{% extends "helpdesk/base.html" %}{% load i18n bootstrap %}
 
 {% block helpdesk_title %}{% trans "Change User Settings" %}{% endblock %}
 


### PR DESCRIPTION
Django 1.8 deprecated the load url from future.

According to Django 1.5 release notes:
https://docs.djangoproject.com/en/1.8/releases/1.5/

This template tag line could be removed safely from that release.

Since the requirements.txt says "Django>1.4". It should be safe to merge this.

