### PR TITLE
Update install.rst

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -46,11 +46,11 @@ Adding To Your Django Project
 
 2. Make sure django-helpdesk is accessible via ``urls.py``. Add the following line to ``urls.py``::
 
-     (r'helpdesk/', include('helpdesk.urls')),
+     url(r'helpdesk/', include('helpdesk.urls')),
 
    Note that you can change 'helpdesk/' to anything you like, such as 'support/' or 'help/'. If you want django-helpdesk to be available at the root of your site (for example at http://support.mysite.tld/) then the line will be as follows::
 
-     (r'', include('helpdesk.urls')),
+     url(r'', include('helpdesk.urls')),
 
    This line will have to come *after* any other lines in your urls.py such as those used by the Django admin.
 


### PR DESCRIPTION
Change example urls.py URL patterns from raw tuples to url(...) calls, for Django 1.8 (and possibly 1.5+) compatibility.

I'm not sure exactly when this changed, but it seems that as of Django 1.8 at least raw tuples don't work in urlpatterns. The Django docs for 1.4 are the last version to show this usage; as of 1.5 the docs only show url() calls in the urlpatterns definition, and I ran into the error on a fresh Django 1.8.2 install.

Since the change is backwards-compatible with 1.4 IIRC, I figured this not a controversial update, but just let me know if it requires any further adjustment or background research.