### PR TITLE
Include attachments to cc'd users on ticket update

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -508,6 +508,7 @@ def update_ticket(request, ticket_id, public=False):
                     recipients=cc.email_address,
                     sender=ticket.queue.from_address,
                     fail_silently=True,
+                    files=files,
                     )
                 messages_sent_to.append(cc.email_address)
 


### PR DESCRIPTION
This patch includes attachments for cc'd users when a ticket is updated. I tracked the issue down to this commit: f419d8e2d009d1f2f2fd242e06cec5a540049a96. Cheers