### PR TITLE
Fix QueueMembership bug revealed by django.test's DiscoverRunner

### DIFF
--- a/helpdesk/tests/test_per_queue_staff_membership.py
+++ b/helpdesk/tests/test_per_queue_staff_membership.py
@@ -17,6 +17,7 @@ class PerQueueStaffMembershipTestCase(TestCase):
         and    user_2 with access to queue_2 containing 2 tickets
         and superuser who should be able to access both queues
         """
+        self.HELPDESK_ENABLE_PER_QUEUE_STAFF_MEMBERSHIP = settings.HELPDESK_ENABLE_PER_QUEUE_STAFF_MEMBERSHIP
         settings.HELPDESK_ENABLE_PER_QUEUE_STAFF_MEMBERSHIP = True
         self.client = Client()
         User = get_user_model()
@@ -58,6 +59,12 @@ class PerQueueStaffMembershipTestCase(TestCase):
                     queue=queue,
                     assigned_to=user,
                 )
+
+    def tearDown(self):
+        """
+        Reset HELPDESK_ENABLE_PER_QUEUE_STAFF_MEMBERSHIP to original value
+        """
+        settings.HELPDESK_ENABLE_PER_QUEUE_STAFF_MEMBERSHIP = self.HELPDESK_ENABLE_PER_QUEUE_STAFF_MEMBERSHIP
 
     def test_dashboard_ticket_counts(self):
         """
@@ -213,9 +220,3 @@ class PerQueueStaffMembershipTestCase(TestCase):
             3,
             'Queue choices were improperly limited by queue membership for a superuser'
         )
-
-    def tearDown(self):
-        """
-        Don't interfere with subsequent tests that do not expect this setting
-        """
-        settings.HELPDESK_ENABLE_PER_QUEUE_STAFF_MEMBERSHIP = False


### PR DESCRIPTION
If HELPDESK_ENABLE_PER_QUEUE_STAFF_MEMBERSHIP was True but a user had
no QueueMembership entries, then restricting queue access generated
RelatedObjectDoesNotExist exceptions.

 - Ask for forgiveness whenever we try to limit a queryset by the
queuemembership related object set.

 - Since tests can now be run with the project's settings active,
rather than only with quicktest.py's settings, restore the initial
HELPDESK_ENABLE_PER_QUEUE_MEMBERSHIP value after having tested the
related functionality.

Closes #353; thanks for catching this @flinz!