### PR TITLE
Bugfix: Integer given as string in models.py

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -1213,7 +1213,7 @@ class CustomField(models.Model):
 
     label = models.CharField(
         _('Label'),
-        max_length='30',
+        max_length=30,
         help_text=_('The display label for this field'),
         )
 


### PR DESCRIPTION
Bugfix, related issue is https://github.com/rossp/django-helpdesk/issues/360.
This reportedly caused problems under postgresql.

Thanks to @alexbarcelo for spotting.

### Changes
- changed max_length given by string to integer;