### PR TITLE
Change supported django+python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: python
+
 python:
     - "2.7"
     - "3.4"
     - "3.5"
+
 env:
     - DJANGO=1.7.11
     - DJANGO=1.8.7
     - DJANGO=1.9
+
+matrix:
+    exclude:
+    - python: "3.5"  # django 1.7 does not support python 3.5
+      env: DJANGO=1.7.11
+
 install:
     - pip install argparse
     - pip install -q Django==$DJANGO
     - pip install -q -r requirements.txt
+
 script: python quicktest.py helpdesk

--- a/README.rst
+++ b/README.rst
@@ -26,7 +26,7 @@ Dependencies (pre-flight checklist)
 -----------------------------------
 
 1. Python 2.7 or 3.4+ (3.4+ support is new, please let us know how it goes)
-2. Django (1.7 or newer, preferably 1.9)
+2. Django (1.7 or newer, preferably 1.9 - Django 1.7 is not supported if you are using Python 3.5)
 3. An existing WORKING Django project with database etc. If you
    cannot log into the Admin, you won't get this product working.
 4. `pip install django-bootstrap-form` and add `bootstrapform` to `settings.INSTALLED_APPS`

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ LICENSE.3RDPARTY for license terms for included packages.
 Dependencies (pre-flight checklist)
 -----------------------------------
 
-1. Python 2.7 or 3.3+ (3.3 support is new, please let us know how it goes)
+1. Python 2.7 or 3.4+ (3.4+ support is new, please let us know how it goes)
 2. Django (1.7 or newer, preferably 1.9)
 3. An existing WORKING Django project with database etc. If you
    cannot log into the Admin, you won't get this product working.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django>1.4
+Django>1.6
 django-bootstrap-form>=3.1,<4
 email-reply-parser
 django-markdown-deux


### PR DESCRIPTION
- support only python 3.4+ (3.3 support is dropped for Django 1.8+) (issue: https://github.com/rossp/django-helpdesk/issues/362)
- drop support for django 1.7 + python 3.5 (not supported)