### PR TITLE
Making Queue slug unique and improving certain admin-related behaviour

### DIFF
--- a/helpdesk/admin.py
+++ b/helpdesk/admin.py
@@ -7,6 +7,7 @@ from helpdesk.models import CustomField
 
 class QueueAdmin(admin.ModelAdmin):
     list_display = ('title', 'slug', 'email_address', 'locale')
+    prepopulated_fields = {"slug": ("title",)}
 
 class TicketAdmin(admin.ModelAdmin):
     list_display = ('title', 'status', 'assigned_to', 'queue', 'hidden_submitter_email',)

--- a/helpdesk/migrations/0011_admin_related_improvements.py
+++ b/helpdesk/migrations/0011_admin_related_improvements.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('helpdesk', '0010_remove_queuemembership'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='queue',
+            name='permission_name',
+            field=models.CharField(editable=False, max_length=50, blank=True, help_text='Name used in the django.contrib.auth permission system', null=True, verbose_name='Django auth permission name'),
+        ),
+        migrations.AlterField(
+            model_name='queue',
+            name='slug',
+            field=models.SlugField(help_text="This slug is used when building ticket ID's. Once set, try not to change it or e-mailing may get messy.", unique=True, verbose_name='Slug'),
+        ),
+    ]

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -45,6 +45,7 @@ class Queue(models.Model):
     slug = models.SlugField(
         _('Slug'),
         max_length=50,
+        unique=True,
         help_text=_('This slug is used when building ticket ID\'s. Once set, '
             'try not to change it or e-mailing may get messy.'),
         )
@@ -179,6 +180,7 @@ class Queue(models.Model):
         max_length=50,
         blank=True,
         null=True,
+        editable=False,
         help_text=_('Name used in the django.contrib.auth permission system'),
         )
 


### PR DESCRIPTION
Most changes are improvements to the admin related to Queues (mainly the auto slug generation in the admin Queue creation).

However, the slug uniqueness is a restriction to avoid bugs between different Queues with the same slug (which, by default, I expect to be a non-desired scenario... it would be awkward, wouldn't it?)