### PR TITLE
Add HELPDESK_ENABLE_PER_QUEUE_MEMBERSHIP to discontinued settings;

### DIFF
--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -173,3 +173,4 @@ The following settings were defined in previous versions and are no longer suppo
 
 - **HELPDESK_FOOTER_SHOW_CHANGE_LANGUAGE_LINK** Is never shown. Use your own template if required.
 
+- **HELPDESK_ENABLE_PER_QUEUE_MEMBERSHIP** Discontinued in favor of HELPDESK_ENABLE_PER_QUEUE_PERMISSION.


### PR DESCRIPTION
This setting was removed in a [recent merge](https://github.com/rossp/django-helpdesk/pull/367), but not added to the discontinued settings section in ``doc/settings.rst``