### PR TITLE
Fix: _meta.module_name deprecated in django1.8

### DIFF
--- a/helpdesk/admin.py
+++ b/helpdesk/admin.py
@@ -6,13 +6,15 @@ from helpdesk.models import TicketChange, Attachment, IgnoreEmail
 from helpdesk.models import CustomField
 
 class QueueAdmin(admin.ModelAdmin):
-    list_display = ('title', 'slug', 'email_address', 'locale')
+    list_display = ('title', 'slug', 'email_address', 'allow_public_submission')
+    list_editable = ('allow_public_submission', )
     prepopulated_fields = {"slug": ("title",)}
 
 class TicketAdmin(admin.ModelAdmin):
-    list_display = ('title', 'status', 'assigned_to', 'queue', 'hidden_submitter_email',)
+    list_display = ('title', 'ticket_type', 'status', 'assigned_to', 'queue', 'hidden_submitter_email',)
+    list_editable = ('ticket_type', 'status')
     date_hierarchy = 'created'
-    list_filter = ('queue', 'assigned_to', 'status')
+    list_filter = ('queue', 'assigned_to', 'ticket_type', 'status')
 
     def hidden_submitter_email(self, ticket):
         if ticket.submitter_email:

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -76,7 +76,7 @@ class CustomFieldMixin(object):
 class EditTicketForm(CustomFieldMixin, forms.ModelForm):
     class Meta:
         model = Ticket
-        exclude = ('created', 'modified', 'status', 'on_hold', 'resolution', 'last_escalation', 'assigned_to')
+        exclude = ('created', 'modified', 'status', 'ticket_type', 'on_hold', 'resolution', 'last_escalation', 'assigned_to')
     
     def __init__(self, *args, **kwargs):
         """
@@ -215,6 +215,7 @@ class TicketForm(CustomFieldMixin, forms.Form):
                     submitter_email = self.cleaned_data['submitter_email'],
                     created = timezone.now(),
                     status = Ticket.OPEN_STATUS,
+                    ticket_type = Ticket.ISSUE_TICKETTYPE,
                     queue = q,
                     description = self.cleaned_data['body'],
                     priority = self.cleaned_data['priority'],
@@ -400,6 +401,7 @@ class PublicTicketForm(CustomFieldMixin, forms.Form):
             submitter_email = self.cleaned_data['submitter_email'],
             created = timezone.now(),
             status = Ticket.OPEN_STATUS,
+            ticket_type = Ticket.ISSUE_TICKETTYPE,
             queue = q,
             description = self.cleaned_data['body'],
             priority = self.cleaned_data['priority'],

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -318,11 +318,26 @@ class Ticket(models.Model):
     the dashboard to prompt users to take ownership of them.
     """
 
+    ISSUE_TICKETTYPE = 1
+    ENHANCEMENT_TICKETTYPE = 2
+    NEW_FEATURE_TICKETTYPE = 3
+    TASK_TICKETTYPE = 4
+    TRAINING_TICKETTYPE = 5
+
+    TICKETTYPE_CHOICES = (
+        (ISSUE_TICKETTYPE, _('Issue / Bug')),
+        (ENHANCEMENT_TICKETTYPE, _('Enhancement')),
+        (NEW_FEATURE_TICKETTYPE, _('New Feature')),
+        (TASK_TICKETTYPE, _('Task / To Do')),
+        (TRAINING_TICKETTYPE, _('Training')),
+    )
+
     OPEN_STATUS = 1
     REOPENED_STATUS = 2
     RESOLVED_STATUS = 3
     CLOSED_STATUS = 4
     DUPLICATE_STATUS = 5
+    WONT_FIX_STATUS = 6
 
     STATUS_CHOICES = (
         (OPEN_STATUS, _('Open')),
@@ -330,6 +345,7 @@ class Ticket(models.Model):
         (RESOLVED_STATUS, _('Resolved')),
         (CLOSED_STATUS, _('Closed')),
         (DUPLICATE_STATUS, _('Duplicate')),
+        (WONT_FIX_STATUS, _('Won\'t Fix')),
     )
 
     PRIORITY_CHOICES = (
@@ -348,6 +364,12 @@ class Ticket(models.Model):
     queue = models.ForeignKey(
         Queue,
         verbose_name=_('Queue'),
+        )
+
+    ticket_type = models.IntegerField(
+        _('Status'),
+        choices=TICKETTYPE_CHOICES,
+        default=ISSUE_TICKETTYPE,
         )
 
     created = models.DateTimeField(

--- a/helpdesk/templates/helpdesk/include/tickets.html
+++ b/helpdesk/templates/helpdesk/include/tickets.html
@@ -2,7 +2,9 @@
 <table class="table table-hover table-bordered table-striped">{% if ticket_list_caption %}
 <caption>{{ ticket_list_caption }}</caption>{% endif %}
 <thead>
-<tr><th>#</th><th>{% trans "Pr" %}</th><th>{% trans "Title" %}</th><th>{% trans "Queue" %}</th><th>{% trans "Status" %}</th><th>{% trans "Last Update" %}</th></tr>
+<tr><th>#</th><th>{% trans "Pr" %}</th><th>{% trans "Title" %}</th><th>{% trans "Queue" %}</th>
+    <th>{% trans "Type" %}</th><th>{% trans "Status" %}</th><th>{% trans "Last Update" %}</th>
+</tr>
 </thead>
 <tbody>
 {% for ticket in ticket_list %}
@@ -11,6 +13,7 @@
 <td>{{ ticket.priority }}</td>
 <th><a href='{{ ticket.get_absolute_url }}'>{{ ticket.title }}</a></th>
 <td>{{ ticket.queue }}</td>
+<td>{{ ticket.get_ticket_type_display }}</td>
 <td>{{ ticket.get_status }}</td>
 <td><span title='{{ ticket.modified|date:"r" }}'>{{ ticket.modified|naturaltime }}</span></td>
 </tr>

--- a/helpdesk/templates/helpdesk/public_view_ticket.html
+++ b/helpdesk/templates/helpdesk/public_view_ticket.html
@@ -21,6 +21,11 @@
 </tr>
 
 <tr>
+    <th>{% trans "Type" %}</th>
+    <td>{{ ticket.get_ticket_type_display }}</td>
+</tr>
+
+<tr>
     <th>{% trans "Priority" %}</th>
     <td>{{ ticket.get_priority_display }}</td>
 </tr>

--- a/helpdesk/templates/helpdesk/ticket.html
+++ b/helpdesk/templates/helpdesk/ticket.html
@@ -180,13 +180,17 @@ function googleTranslateElementInit() {
     <dl>
 
         <dt><label for='id_title'>{% trans "Title" %}</label></dt>
-        <dd><input type='text' name='title' value='{{ ticket.title|escape }}' /></dd>
+        <dd><input id='id_title' type='text' name='title' value='{{ ticket.title|escape }}' /></dd>
 
         <dt><label for='id_owner'>{% trans "Owner" %}</label></dt>
         <dd><select id='id_owner' name='owner'><option value='0'>{% trans "Unassign" %}</option>{% for u in active_users %}<option value='{{ u.id }}' {% ifequal u.id ticket.assigned_to.id %}selected{% endifequal %}>{{ u }}</option>{% endfor %}</select></dd>
 
+        <dt><label for='id_ticket_type'>{% trans "Type" %}</label></dt>
+        <dd><select id='id_ticket_type' name='ticket_type'>{% for t in ticket_types %}<option value='{{ t.0 }}'{% ifequal t.0 ticket.ticket_type %} selected='selected'{% endifequal %}>{{ t.1 }}</option>{% endfor %}</select></dd>
+
         <dt><label for='id_priority'>{% trans "Priority" %}</label></dt>
         <dd><select id='id_priority' name='priority'>{% for p in priorities %}<option value='{{ p.0 }}'{% ifequal p.0 ticket.priority %} selected='selected'{% endifequal %}>{{ p.1 }}</option>{% endfor %}</select></dd>
+
         <dt><label for='id_due_date'>{% trans "Due on" %}</label></dt>
         <dd>{{ form.due_date }}</dd>
 

--- a/helpdesk/templates/helpdesk/ticket_desc_table.html
+++ b/helpdesk/templates/helpdesk/ticket_desc_table.html
@@ -45,6 +45,11 @@
 </tr>
 
 <tr>
+    <th>{% trans "Type" %}</th>
+    <td>{{ ticket.get_ticket_type_display }}</td>
+</tr>
+
+<tr>
     <th>{% trans "Priority" %}</th>
     <td>{{ ticket.get_priority_display }}</td>
 </tr>

--- a/helpdesk/templates/helpdesk/ticket_list.html
+++ b/helpdesk/templates/helpdesk/ticket_list.html
@@ -67,6 +67,7 @@ $(document).ready(function() {
         <option value='Sort'>{% trans "Sorting" %}</option>
         <option value='Owner'>{% trans "Owner" %}</option>
         <option value='Queue'>{% trans "Queue" %}</option>
+        <option value='Type'>{% trans "Type" %}</option>
         <option value='Status'>{% trans "Status" %}</option>
         <option value='Keywords'>{% trans "Keywords" %}</option>
         <option value='Dates'>{% trans "Date Range" %}</option>
@@ -86,6 +87,9 @@ $(document).ready(function() {
         </option>
         <option value='queue'{% ifequal query_params.sorting "queue"%} selected='selected'{% endifequal %}>
             {% trans "Queue" %}
+        </option>
+        <option value='ticket_type'{% ifequal query_params.sorting "ticket_type"%} selected='selected'{% endifequal %}>
+            {% trans "Type" %}
         </option>
         <option value='status'{% ifequal query_params.sorting "status"%} selected='selected'{% endifequal %}>
             {% trans "Status" %}
@@ -118,6 +122,12 @@ $(document).ready(function() {
 
     <div class='thumbnail filterBox{% if query_params.filtering.queue__id__in %} filterBoxShow{% endif %}' id='filterBoxQueue'>
     <label for='id_queues'>{% trans "Queue(s)" %}</label><select id='id_queues' name='queue' multiple='selected' size='5'>{% for q in queue_choices %}<option value='{{ q.id }}'{% if q.id|in_list:query_params.filtering.queue__id__in %} selected='selected'{% endif %}>{{ q.title }}</option>{% endfor %}</select>
+    <p class='filterHelp'>{% trans "Ctrl-click to select multiple options" %}</p>
+    <input type='button' class='filterBuilderRemove' value='-' />
+    </div>
+
+    <div class='thumbnail filterBox{% if query_params.filtering.ticket_type__in %} filterBoxShow{% endif %}' id='filterBoxType'>
+    <label for='id_ticket_types'>{% trans "Type(s)" %}</label><select id='id_ticket_types' name='ticket_type' multiple='selected' size='5'>{% for t in ticket_type_choices %}<option value='{{ t.0 }}'{% if t.0|in_list:query_params.filtering.ticket_type__in %} selected='selected'{% endif %}>{{ t.1 }}</option>{% endfor %}</select>
     <p class='filterHelp'>{% trans "Ctrl-click to select multiple options" %}</p>
     <input type='button' class='filterBuilderRemove' value='-' />
     </div>
@@ -222,7 +232,8 @@ $(document).ready(function() {
 <table class="table table-hover table-bordered table-striped">
 <caption>{% trans "Tickets" %}</caption>
 <thead>
-<tr><th>#</th><th>&nbsp;</th><th>{% trans "Pr" %}</th><th>{% trans "Title" %}</th><th>{% trans "Queue" %}</th><th>{% trans "Status" %}</th><th>{% trans "Created" %}</th><th>{% trans "Owner" %}</th></tr>
+<tr><th>#</th><th>&nbsp;</th><th>{% trans "Pr" %}</th><th>{% trans "Title" %}</th><th>{% trans "Queue" %}</th>
+    <th>{% trans "Type" %}</th><th>{% trans "Status" %}</th><th>{% trans "Created" %}</th><th>{% trans "Owner" %}</th></tr>
 </thead>
 <tbody>
 {% for ticket in tickets.object_list %}
@@ -232,6 +243,7 @@ $(document).ready(function() {
 <td>{{ ticket.priority }}</td>
 <th><a href='{{ ticket.get_absolute_url }}'>{{ ticket.title }}</a></th>
 <td>{{ ticket.queue }}</td>
+<td>{{ ticket.get_ticket_type_display }}</td>
 <td>{{ ticket.get_status }}</td>
 <td><span title='{{ ticket.created|date:"r" }}'>{{ ticket.created|naturaltime }}</span></td>
 <td>{{ ticket.get_assigned_to }}</td>

--- a/helpdesk/templatetags/user_admin_url.py
+++ b/helpdesk/templatetags/user_admin_url.py
@@ -14,8 +14,13 @@ from django.contrib.auth import get_user_model
 
 def user_admin_url(action):
     user = get_user_model()
+    try:
+        model_name = user._meta.module_name.lower()
+    except AttributeError:  # module_name alias removed in django 1.8
+        model_name = user._meta.model_name.lower()
+
     return 'admin:%s_%s_%s' % (
-        user._meta.app_label, user._meta.module_name.lower(),
+        user._meta.app_label, model_name,
         action)
 
 register = template.Library()


### PR DESCRIPTION
This patch fixes #377 (tested) while maintaining backward compatibility for earlier versions of django (assumed, not tested)