### PR TITLE
Fix: _meta.module_name deprecated in django1.8

### DIFF
--- a/helpdesk/templatetags/user_admin_url.py
+++ b/helpdesk/templatetags/user_admin_url.py
@@ -14,8 +14,13 @@ from django.contrib.auth import get_user_model
 
 def user_admin_url(action):
     user = get_user_model()
+    try:
+        model_name = user._meta.module_name.lower()
+    except AttributeError:  # module_name alias removed in django 1.8
+        model_name = user._meta.model_name.lower()
+
     return 'admin:%s_%s_%s' % (
-        user._meta.app_label, user._meta.module_name.lower(),
+        user._meta.app_label, model_name,
         action)
 
 register = template.Library()


### PR DESCRIPTION
This updated patch fixes #377 (tested) while maintaining backward compatibility for earlier versions of django (assumed, not tested).   I hope now I created a branch for this patch and the pull request comes in with only the small change needed to fix this issue.  Sorry for earlier mess.