### PR TITLE
dashboard error queues are null 

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -132,8 +132,11 @@ def dashboard(request):
 
     from_clause = """FROM    helpdesk_ticket t,
                     helpdesk_queue q"""
-    where_clause = """WHERE   q.id = t.queue_id AND
-                    q.id IN (%s)""" % (",".join(("%d" % pk for pk in queues)))
+    if queues:
+        where_clause = """WHERE   q.id = t.queue_id AND
+                        q.id IN (%s)""" % (",".join(("%d" % pk for pk in queues)))
+    else:
+        where_clause = """WHERE   q.id = t.queue_id"""
 
     cursor = connection.cursor()
     cursor.execute("""


### PR DESCRIPTION
(1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')\n            GROUP BY queue, name\n            ORDER BY q.id' at line 9") helpdesk/views/staff.py in dashboard 149 solved. When queues are null do not add to sql q.id in ()