### PR TITLE
Changes to templates to make them compatible with django 1.10

### DIFF
--- a/helpdesk/templates/helpdesk/debug.html
+++ b/helpdesk/templates/helpdesk/debug.html
@@ -19,7 +19,7 @@
                 </tr>
                 </thead>
                 <tbody>
-                {% for query in sql_queries %}<tr class="{% cycle odd,even %}">
+                {% for query in sql_queries %}<tr class="{% cycle 'odd' 'even' %}">
                     <td>{{ forloop.counter }}</td>
                     <td>{{ query.sql|escape }}</td>
                     <td>{{ query.time }}</td>

--- a/helpdesk/templates/helpdesk/email_ignore_list.html
+++ b/helpdesk/templates/helpdesk/email_ignore_list.html
@@ -14,7 +14,7 @@
 </thead>
 <tbody>
 {% for ignore in ignore_list %}
-<tr class='row_{% cycle odd,even %}'>
+<tr class='row_{% cycle 'odd' 'even' %}'>
     <td>{{ ignore.name }}</td>
     <td>{{ ignore.email_address }}</td>
     <td>{{ ignore.date }}</td>

--- a/helpdesk/templates/helpdesk/report_output.html
+++ b/helpdesk/templates/helpdesk/report_output.html
@@ -37,7 +37,7 @@
 </thead>
 <tbody>
 {% for d in data %}
-<tr class='row_{% cycle odd,even %}'>{% for f in d %}<td class='report'>{{ f }}</td>{% endfor %}</tr>{% endfor %}
+<tr class='row_{% cycle 'odd' 'even' %}'>{% for f in d %}<td class='report'>{{ f }}</td>{% endfor %}</tr>{% endfor %}
 </tbody>
 </table>
 

--- a/helpdesk/templates/helpdesk/ticket_cc_list.html
+++ b/helpdesk/templates/helpdesk/ticket_cc_list.html
@@ -16,7 +16,7 @@
 </thead>
 <tbody>
 {% for person in copies_to %}
-<tr class='row_{% cycle odd,even %}'>
+<tr class='row_{% cycle 'odd' 'even' %}'>
     <td>{{ person.display }}</td>
     <td>{{ person.can_view }}</td>
     <td>{{ person.can_update }}</td>


### PR DESCRIPTION
Specifically the 'cycle' tag has changed, now only allows space separated arguments.
The 4 commits in this PR are compatible with django 1.9.7, haven't tested any django versions prior to 1.9.7
Tested on 1.10a1 (latest at this point in time)
