### PR TITLE
Fix import error on python 3 get_email command

### DIFF
--- a/helpdesk/management/commands/get_email.py
+++ b/helpdesk/management/commands/get_email.py
@@ -20,7 +20,7 @@ import socket
 
 from datetime import timedelta
 from email.header import decode_header
-from email.Utils import parseaddr, collapse_rfc2231_value
+from email.utils import parseaddr, collapse_rfc2231_value
 from optparse import make_option
 
 from email_reply_parser import EmailReplyParser


### PR DESCRIPTION
"from email.utils import parseaddr, collapse_rfc2231_value" works both for python 2.7 and python 3