### PR TITLE
django.contrib.sites is an requirement

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,7 +35,7 @@ Adding To Your Django Project
         'django.contrib.auth',
         'django.contrib.contenttypes',
         'django.contrib.sessions',
-        'django.contrib.sites',
+        'django.contrib.sites',  # Required for determing domain url for use in emails
         'django.contrib.admin',  # Required for helpdesk admin/maintenance
         'django.contrib.humanize',  # Required for elapsed time formatting
         'markdown_deux',  # Required for Knowledgebase item formatting


### PR DESCRIPTION
Documentation example should point out django.contrib.sites is a requirement. I thought "sites" was optional looking at example first time. Ref. issue #400.