### PR TITLE
Ticket #403 - Ignore queue name when doing lookups for tickets

### DIFF
--- a/helpdesk/tests/test_ticket_lookup.py
+++ b/helpdesk/tests/test_ticket_lookup.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+from helpdesk.models import Ticket, Queue
+
+class TestKBDisabled(TestCase):
+    def setUp(self):
+        q = Queue(title='Q1', slug='q1')
+        q.save()
+        t = Ticket(title='Test Ticket', submitter_email='test@domain.com')
+        t.queue = q
+        t.save()
+        self.ticket = t
+
+    def test_ticket_by_id(self):
+        """Can a ticket be looked up by its ID"""
+        from django.core.urlresolvers import NoReverseMatch
+
+        # get the ticket from models
+        t = Ticket.objects.get(id=self.ticket.id)
+        self.assertEqual(t.title, self.ticket.title)
+
+    def test_ticket_by_link(self):
+        """Can a ticket be looked up by its link from (eg) an email"""
+        # Work out the link which would have been inserted into the email
+        link = self.ticket.ticket_url
+        # however instead of using that link, we will exercise 'reverse'
+        # to lookup/build the URL from the ticket info we have
+        #  http://example.com/helpdesk/view/?ticket=q1-1&email=None
+        response = self.client.get(reverse('helpdesk_public_view'),
+                                   {'ticket': self.ticket.ticket_for_url,
+                                    'email':self.ticket.submitter_email})
+        self.assertEqual(response.status_code, 200)
+
+    def test_ticket_with_changed_queue(self):
+        # Make a ticket (already done in setup() )
+        # Now make another queue
+        q2 = Queue(title='Q2', slug='q2')
+        q2.save()
+        # grab the URL / params which would have been emailed out to submitter.
+        url = reverse('helpdesk_public_view')
+        params = {'ticket': self.ticket.ticket_for_url,
+                  'email':self.ticket.submitter_email}
+        # Pickup the ticket created in setup() and change its queue
+        self.ticket.queue = q2
+        self.ticket.save()
+
+        # confirm that we can still get to a url which was emailed earlier
+        response = self.client.get(url, params)
+        self.assertNotContains(response, "Invalid ticket ID")

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -83,7 +83,7 @@ def view_ticket(request):
         ticket_id = parts[-1]
 
         try:
-            ticket = Ticket.objects.get(id=ticket_id, queue__slug__iexact=queue, submitter_email__iexact=email)
+            ticket = Ticket.objects.get(id=ticket_id, submitter_email__iexact=email)
         except:
             ticket = False
             error_message = _('Invalid ticket ID or e-mail address. Please try again.')


### PR DESCRIPTION
This code changes the behaviour of lookups for tickets and 
ignores the queue name. This means that queue changes on a ticket dont
break the email links which have already been sent out.
The queue name still exists in the link/url, but is not used in the
lookup