### PR TITLE
Fix Issue #404: Refactor converting query string into queue:id

### DIFF
--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -562,6 +562,14 @@ class Ticket(models.Model):
 
         super(Ticket, self).save(*args, **kwargs)
 
+    @classmethod
+    def queue_and_id_from_query(klass, query):
+        # Apply the opposite logic here compared to self._get_ticket_for_url
+        # Ensure that queues with '-' in them will work
+        parts = query.split('-')
+        queue = '-'.join(parts[0:-1])
+        return queue, parts[-1]
+
 
 class FollowUpManager(models.Manager):
     def private_followups(self):

--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -78,10 +78,7 @@ def view_ticket(request):
     error_message = ''
 
     if ticket_req and email:
-        parts = ticket_req.split('-')
-        queue = '-'.join(parts[0:-1])
-        ticket_id = parts[-1]
-
+        queue, ticket_id = Ticket.queue_and_id_from_query(ticket_req)
         try:
             ticket = Ticket.objects.get(id=ticket_id, submitter_email__iexact=email)
         except:

--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -739,7 +739,7 @@ def ticket_list(request):
         filter = None
         if query.find('-') > 0:
             try:
-                queue, id = query.split('-')
+                queue, id = Ticket.queue_and_id_from_query(query)
                 id = int(id)
             except ValueError:
                 id = None


### PR DESCRIPTION
There are two places in views where query strings such as "my-queue:33" are split into the queue name and the ticket ID. This PR refactors these into one place (in models), which as a side effect, enables both views to handle queues with a dash in their slug (ie "my-queue").
No test included (already has 100% coverage by existing tests)