### PR TITLE
fix #408 : Bug in test_per_queue_staff_permission.py

### DIFF
--- a/helpdesk/tests/test_per_queue_staff_permission.py
+++ b/helpdesk/tests/test_per_queue_staff_permission.py
@@ -41,7 +41,7 @@ class PerQueueStaffMembershipTestCase(TestCase):
                 username='User_%d' % identifier,
                 is_staff=True,
             )
-            user.set_password(identifier)
+            user.set_password(str(identifier))
             user.save()
 
             # The prefix 'helpdesk.' must be trimmed
@@ -74,7 +74,7 @@ class PerQueueStaffMembershipTestCase(TestCase):
 
         # Regular users
         for identifier in self.IDENTIFIERS:
-            self.client.login(username='User_%d' % identifier, password=identifier)
+            self.client.login(username='User_%d' % identifier, password=str(identifier))
             response = self.client.get(reverse('helpdesk_dashboard'))
             self.assertEqual(
                 len(response.context['unassigned_tickets']),
@@ -131,7 +131,7 @@ class PerQueueStaffMembershipTestCase(TestCase):
         """
         # Regular users
         for identifier in self.IDENTIFIERS:
-            self.client.login(username='User_%d' % identifier, password=identifier)
+            self.client.login(username='User_%d' % identifier, password=str(identifier))
             response = self.client.get(reverse('helpdesk_list'))
             self.assertEqual(
                 len(response.context['tickets']),
@@ -166,7 +166,7 @@ class PerQueueStaffMembershipTestCase(TestCase):
         """
         # Regular users
         for identifier in self.IDENTIFIERS:
-            self.client.login(username='User_%d' % identifier, password=identifier)
+            self.client.login(username='User_%d' % identifier, password=str(identifier))
             response = self.client.get(
                 reverse('helpdesk_run_report', kwargs={'report': 'userqueue'})
             )


### PR DESCRIPTION
Using the django auth backend allows integers to be passed as a password
Using Peter Sagerson's ldap auth backend there is an error thrown because
some code tries to do a len() on the password.
You could argue that the ldap auth backend should str(password), but
you could also argue that passing an int as a password is bad practice

This PR ensures that a string is sent to the auth module.