### PR TITLE
JSON Serialization broke Keyword-Searches

### DIFF
--- a/helpdesk/views/staff.py
+++ b/helpdesk/views/staff.py
@@ -724,7 +724,7 @@ def ticket_list(request):
         'sorting': None,
         'sortreverse': False,
         'keyword': None,
-        'other_filter': None,
+        'search_string': None,
         }
 
     from_saved_query = False
@@ -832,15 +832,8 @@ def ticket_list(request):
         q = request.GET.get('q', None)
 
         if q:
-            qset = (
-                Q(title__icontains=q) |
-                Q(description__icontains=q) |
-                Q(resolution__icontains=q) |
-                Q(submitter_email__icontains=q)
-            )
             context = dict(context, query=q)
-
-            query_params['other_filter'] = qset
+            query_params['search_string'] = q
 
         ### SORTING
         sort = request.GET.get('sort', None)


### PR DESCRIPTION
While my last patch fixed the remote code execution, serializing the query
using JSON for SavedSearches unfortunately broke Keyword-Searches.
This happens when the query_params dict contains a "qset", which is not json-serializable.

Now, only the search string is serialized for saving and
the "qset" is moved from "other_filters" to lib.apply_query.

Sorry for your inconvenience.

Kind regards,

Matthias