### PR TITLE
Syntax correction for Python 3.4 and 3.5

### DIFF
--- a/helpdesk/akismet.py
+++ b/helpdesk/akismet.py
@@ -133,7 +133,7 @@ class Akismet(object):
     def _safeRequest(self, url, data, headers):
         try:
             resp = _fetch_url(url, data, headers)
-        except Exception, e:
+        except Exception as e:
             raise AkismetError(str(e))
         return resp
 


### PR DESCRIPTION
There is no longer accepted this notation in Python 3.4 and 3.5:

```
  File "/usr/lib/python3.5/akismet.py", line 136
    except Exception, e:
                    ^
SyntaxError: invalid syntax
```